### PR TITLE
field name timestamp partitioning

### DIFF
--- a/src/main/java/io/aiven/kafka/connect/common/config/AivenCommonConfig.java
+++ b/src/main/java/io/aiven/kafka/connect/common/config/AivenCommonConfig.java
@@ -28,12 +28,14 @@ import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
 
+import io.aiven.kafka.connect.common.config.TimestampSource.FieldNameTimeStampSource;
 import io.aiven.kafka.connect.common.config.validators.FileCompressionTypeValidator;
 import io.aiven.kafka.connect.common.config.validators.OutputFieldsEncodingValidator;
 import io.aiven.kafka.connect.common.config.validators.OutputFieldsValidator;
 import io.aiven.kafka.connect.common.config.validators.OutputTypeValidator;
 import io.aiven.kafka.connect.common.grouper.RecordGrouperFactory;
 import io.aiven.kafka.connect.common.templating.Template;
+
 
 public class AivenCommonConfig extends AbstractConfig {
     public static final String FORMAT_OUTPUT_FIELDS_CONFIG = "format.output.fields";
@@ -45,6 +47,7 @@ public class AivenCommonConfig extends AbstractConfig {
     public static final String FILE_NAME_TIMESTAMP_TIMEZONE = "file.name.timestamp.timezone";
     public static final String FILE_NAME_TIMESTAMP_SOURCE = "file.name.timestamp.source";
     public static final String FILE_NAME_TEMPLATE_CONFIG = "file.name.template";
+    public static final String PARTITION_FIELD_NAME = "partition.field.name";
 
     private static final String GROUP_AWS = "AWS";
     private static final String GROUP_FILE = "File";
@@ -249,10 +252,15 @@ public class AivenCommonConfig extends AbstractConfig {
     }
 
     public final TimestampSource getFilenameTimestampSource() {
-        return TimestampSource.of(
+        final TimestampSource timestampSource = TimestampSource.of(
             getFilenameTimezone(),
             TimestampSource.Type.of(getString(FILE_NAME_TIMESTAMP_SOURCE))
         );
+        if (timestampSource.getClass().equals(FieldNameTimeStampSource.class)) {
+          ((FieldNameTimeStampSource) timestampSource)
+              .setPartitionFieldName(getString(PARTITION_FIELD_NAME));
+        }
+        return timestampSource;
     }
 
     public final int getMaxRecordsPerFile() {

--- a/src/test/java/io/aiven/kafka/connect/common/config/TimestampSourceTest.java
+++ b/src/test/java/io/aiven/kafka/connect/common/config/TimestampSourceTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2021 Aiven Oy
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.aiven.kafka.connect.common.config;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.Optional;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.aiven.kafka.connect.common.config.TimestampSource.FieldNameTimeStampSource;
+import io.aiven.kafka.connect.common.config.TimestampSource.Type;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TimestampSourceTest {
+    final String partitionFieldName = "event.occurrence.timestamp";
+
+    @Test
+    void fieldNamePartitionExceptions() {
+
+        final Schema schemaWithOutPartitionField = SchemaBuilder.struct()
+            .name("com.example.no_partition_field").version(1)
+            .field("month", Schema.STRING_SCHEMA)
+            .build();
+
+        final TimestampSource timestampSourceFieldName = TimestampSource.of(Type.PARTITION_FIELDNAME);
+
+        final Struct value = new Struct(schemaWithOutPartitionField);
+        value.put("month", "January");
+
+        final SinkRecord sinkRecordNoPartitionField = new SinkRecord(
+            "topic0", 0,
+            SchemaBuilder.string().optional().version(1).build(), "some_key",
+            schemaWithOutPartitionField, value, 1);
+
+        // partition field not set, exception is expected here
+        assertThrows(DataException.class, () -> {
+            timestampSourceFieldName.time(Optional.of(sinkRecordNoPartitionField));
+        });
+
+        ((FieldNameTimeStampSource) timestampSourceFieldName).setPartitionFieldName(partitionFieldName);
+        // partition field is set, but the field doesn't exist
+        assertThrows(DataException.class, () -> {
+            timestampSourceFieldName.time(Optional.of(sinkRecordNoPartitionField));
+        });
+    }
+
+    @Test
+    void fieldNamePartition() {
+
+        final Schema schemaWithPartitionField = SchemaBuilder.struct()
+            .name("com.example.with_partition_field").version(1)
+            .field("month", Schema.STRING_SCHEMA)
+            .field(partitionFieldName, Schema.INT64_SCHEMA)
+            .build();
+
+        final TimestampSource timestampSourceFieldName = TimestampSource.of(Type.PARTITION_FIELDNAME);
+        ((FieldNameTimeStampSource) timestampSourceFieldName).setPartitionFieldName(partitionFieldName);
+
+        final Long eventOccurrenceTimestamp = 1637035167540L;
+        final ZonedDateTime expectedDatetime = ZonedDateTime
+            .ofInstant(Instant.ofEpochMilli(eventOccurrenceTimestamp), ZoneOffset.UTC);
+
+        final Struct value = new Struct(schemaWithPartitionField);
+        value.put("month", "January");
+        value.put(partitionFieldName, eventOccurrenceTimestamp);
+
+        final SinkRecord sinkRecordWithPartitionField = new SinkRecord(
+            "topic1", 0,
+            SchemaBuilder.string().optional().version(1).build(), "some_key",
+            schemaWithPartitionField, value, 2);
+
+        final ZonedDateTime actualDateTime = timestampSourceFieldName.time(Optional.of(sinkRecordWithPartitionField));
+
+        assertEquals(actualDateTime, expectedDatetime);
+    }
+}


### PR DESCRIPTION
This PR also relates to issue https://github.com/aiven/commons-for-apache-kafka-connect/issues/65 and is aimed towards adding fieldname timestamp partitioning.

For the time being, the changes in this PR support extracting values from root field names, for underlying timestamp values that can be cast to the Java Number Class to be used as epoch milliseconds. 

Nested fields and other date sources are on our radar. 

The company I work for, Squarespace, has been using the changes in this PR (via our own internal fork) to successfully sink data to GCS (where resulting directories are partitioned by a record's timestamp field).

We are opening this PR to get feedback from the maintainers and perhaps find a path towards getting these changes onto the main branch. 