### PR TITLE
Change GitHub Actions cache key to invalidate cache

### DIFF
--- a/.github/workflows/master_push_workflow.yml
+++ b/.github/workflows/master_push_workflow.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
-          # cache: gradle
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: Build with Gradle
         run: ./gradlew build

--- a/.github/workflows/master_push_workflow.yml
+++ b/.github/workflows/master_push_workflow.yml
@@ -21,6 +21,6 @@ jobs:
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'temurin'
-          cache: gradle
+          # cache: gradle
       - name: Build with Gradle
         run: ./gradlew build


### PR DESCRIPTION
Even if it seems unlikely, it really appears that we're getting :x: failed checks on **master** and **PRs** due to a corrupted cache.  The same PR works on my fork when the cache is enabled, and disabling the cache works on this repo.

AFAICT, there isn't any way to clear the cache, but we can either (1) turn it off for a week, since all the cached packages are dropped after seven days, or (2) directly call `actions/cache` with a new cache id to create a new cache.  This PR implements the second option.

You can't specify the cache id using `actions/setup-java` unfortunately.

Either way, we can revert this commit in 7 days and restore the "normal" cache mode integrated with `setup-java`.

