### PR TITLE
Make connect-json dependency compile-only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -106,8 +106,8 @@ distributions {
 dependencies {
     compileOnly "org.apache.kafka:connect-api:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
+    compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    implementation "org.apache.kafka:connect-json:$kafkaVersion"
     implementation "io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion"
 
     implementation "org.xerial.snappy:snappy-java:1.1.8.4"


### PR DESCRIPTION
This library is provided in the Connect worker and hence should be used as compile-only. The positive side effect is improved security with having less transitive dependencies.