### PR TITLE
Exclude transitive kafka-clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,9 @@ dependencies {
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    implementation "io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion"
+    implementation("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
+        exclude group: "org.apache.kafka", module: "kafka-clients"
+    }
 
     implementation "org.xerial.snappy:snappy-java:1.1.8.4"
     implementation "com.github.luben:zstd-jni:1.5.2-2"


### PR DESCRIPTION
This dependency is provided when the connector is run in a Connect worker.