### PR TITLE
fix: set avro-converter as compile-only dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    compileOnly("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
+    compileOnly("io.confluent:kafka-connect-avro-data:$confluentPlatformVersion") {
         exclude group: "org.apache.kafka", module: "kafka-clients"
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,7 @@ dependencies {
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    implementation("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
+    compileOnly("io.confluent:kafka-connect-avro-converter:$confluentPlatformVersion") {
         exclude group: "org.apache.kafka", module: "kafka-clients"
     }
 


### PR DESCRIPTION
Kafka Avro Converter libraries should be provided at runtime by the Connect worker, and should not be shipped with the Connectors themselves.

Related issues:
- https://github.com/aiven/gcs-connector-for-apache-kafka/issues/189