### PR TITLE
fix: set avro-data dep back to implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Shared common functionality among Aiven's connectors for Apache Kafka:
 - [Aiven GCS Connector](https://github.com/aiven/gcs-connector-for-apache-kafka)
 - [Aiven S3 Connector](https://github.com/aiven/s3-connector-for-apache-kafka)
 
+# Usage
+
+When installing this library on Kafka Connect, use a specific plugin path, and **avoid placing them on the same path as the Kafka Connect binaries**, as some libraries may have conflicting versions.
+
 # Development
 
 To use this library for development, you need to build and publish it in your local Maven repository using command:

--- a/build.gradle
+++ b/build.gradle
@@ -108,9 +108,7 @@ dependencies {
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    compileOnly("io.confluent:kafka-connect-avro-data:$confluentPlatformVersion") {
-        exclude group: "org.apache.kafka", module: "kafka-clients"
-    }
+    implementation("io.confluent:kafka-connect-avro-data:$confluentPlatformVersion")
 
     implementation "org.xerial.snappy:snappy-java:1.1.10.0"
     implementation "com.github.luben:zstd-jni:1.5.5-3"


### PR DESCRIPTION
Rollback #165 and replace avro converter with `avro-data`, as it's the only library needed when creating avro files.

Also, `avro-data` does not carry kafka-clients as dependency, so removing the exclusion as well.