### PR TITLE
fix(build): remove kafka-clients from distribution

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -108,7 +108,9 @@ dependencies {
     compileOnly "org.apache.kafka:connect-runtime:$kafkaVersion"
     compileOnly "org.apache.kafka:connect-json:$kafkaVersion"
 
-    implementation("io.confluent:kafka-connect-avro-data:$confluentPlatformVersion")
+    implementation("io.confluent:kafka-connect-avro-data:$confluentPlatformVersion") {
+        exclude group: "org.apache.kafka", module: "kafka-clients"
+    }
 
     implementation "org.xerial.snappy:snappy-java:1.1.10.1"
     implementation "com.github.luben:zstd-jni:1.5.5-4"


### PR DESCRIPTION
https://github.com/aiven/commons-for-apache-kafka-connect/pull/166 mistakenly added kafka-clients to the distributions.

Fix #175  